### PR TITLE
Add 4x5 moodboard cropping and enforce limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Carousel Preview
+
+Carousel Preview is a lightweight web tool for quickly arranging and previewing Instagram carousel posts. Upload images, drag to reorder, and export filenames or a moodboard PDF. The project was created by Aviram, a software production agency.
+
+The preview area displays slides in a four-column contact-sheet grid so you can review the whole sequence at once.
+
+## Features
+
+- **Drag & Drop Uploads** – Add images by selecting files or dropping them into the browser.
+- **Paste Support** – Paste images directly from the clipboard.
+- **Reordering** – Use drag and drop (via [Sortable](https://github.com/SortableJS/Sortable)) to change the order of slides.
+- **Contact Sheet View** – Slides are shown four across for an at-a-glance overview.
+- **20 Image Limit** – Upload up to twenty images per project.
+- **Caption & Tags** – Compose copy and tags alongside the carousel.
+- **Exports**
+  - **Filename list** – Download a text file of image filenames in order.
+  - **Moodboard** – Create a landscape PDF contact sheet (1920×1080) with a 4×3 grid. Images are cropped to Instagram's 1080×1350 resolution using [jsPDF](https://github.com/parallax/jsPDF).
+  - **Metadata** – Export captions, tags, and image details.
+- **Safe Zone Overlay** – Optional mask to visualize Instagram's 4:5 safe area.
+- **Light/Dark Toggle** – Switch the interface theme at any time.
+- **Per-image Actions** – Quickly preview, replace, duplicate, or delete each slide.
+- **Dark Mode** – Adapts to system dark mode preferences.
+
+## Development
+
+No build steps are required. Clone the repo and open `index.html` in a modern browser. The JavaScript (`script.js`) and styles (`styles.css`) can be edited directly.
+
+## Project Structure
+
+```
+index.html   -- Main HTML page
+script.js     -- Carousel logic and export features
+script.old.js -- Original script kept for reference
+styles.css    -- Layout and theme styles
+```
+
+## License
+
+This project is provided as-is for demonstration and is not currently licensed for commercial use.
+

--- a/index.html
+++ b/index.html
@@ -9,21 +9,34 @@
 <body>
     <div class="container">
         <h1>Carousel Preview</h1>
+        <div class="toolbar">
+            <label class="toggle">
+                <input type="checkbox" id="themeToggle">
+                <span>Dark mode</span>
+            </label>
+            <label class="toggle">
+                <input type="checkbox" id="safeZoneToggle">
+                <span>Show Instagram Safe Zone</span>
+            </label>
+        </div>
         <div class="upload-section">
             <label for="imageUpload" class="upload-label">
-                <p>Drag & drop images here, or click to select files</p>
+                <span class="upload-icon">📷</span>
+                <p>Drop your carousel here – up to 20 images</p>
             </label>
             <input type="file" id="imageUpload" multiple accept="image/*" style="display: none;">
         </div>
         <div class="carousel-section" id="carouselSection"></div>
         <div class="copy-section">
-            <textarea id="scratchCopy" placeholder="Enter your caption here..."></textarea>
-            <input type="text" id="tags" placeholder="Enter tags here...">
+            <label for="scratchCopy">Caption</label>
+            <textarea id="scratchCopy" placeholder="Type caption..."></textarea>
+            <label for="tags">Tags</label>
+            <input type="text" id="tags" placeholder="tag1 tag2">
         </div>
-        <div class="dock" style="display: flex; justify-content: center; align-items: center;">
-            <span>Export:</span>
-            <button id="exportFilenameList" class="export-btn">📄 Filenames</button>
-            <button id="exportMoodboard" class="export-btn">🖼️ Moodboard</button>
+        <div class="dock">
+            <button id="exportFilenameList" class="export-btn" title="Download ordered filenames">📄 Filenames</button>
+            <button id="exportMoodboard" class="export-btn" title="Create moodboard PDF">🖼️ Moodboard</button>
+            <button id="exportMetadata" class="export-btn" title="Export caption, tags and image list">📝 Metadata</button>
         </div>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.14.0/Sortable.min.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,20 @@ body {
     transition: background-color 0.3s, color 0.3s;
 }
 
+.toolbar {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.toggle {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 14px;
+}
+
 :root {
     --background-color: #ffffff;
     --text-color: #000000;
@@ -43,44 +57,47 @@ h1 {
     display: none;
 }
 
-.upload-section p {
+.upload-label {
     border: 2px dashed #ccc;
     padding: 20px;
     cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+.upload-icon {
+    font-size: 32px;
 }
 
 .carousel-section {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     gap: 20px;
     padding: 20px;
     margin-bottom: 30px;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scroll-snap-type: x mandatory;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-    min-height: 400px;
-    align-items: center;
-}
-
-.carousel-section::-webkit-scrollbar {
-    display: none;
+    justify-items: center;
 }
 
 .img-container {
     position: relative;
-    flex: 0 0 auto;
-    width: 320px;
-    height: 400px;
-    scroll-snap-align: start;
+    width: 100%;
+    max-width: 200px;
+    aspect-ratio: 4 / 5;
     background-color: #f0f0f0;
     border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
     overflow: hidden;
     display: flex;
     justify-content: center;
     align-items: center;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    cursor: grab;
+}
+
+.img-container:active {
+    cursor: grabbing;
 }
 
 .img-container::after {
@@ -88,11 +105,11 @@ h1 {
     position: absolute;
     bottom: 10px;
     left: 10px;
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.6);
     color: white;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 14px;
+    padding: 2px 6px;
+    border-radius: 12px;
+    font-size: 12px;
     z-index: 2;
 }
 
@@ -117,6 +134,13 @@ h1 {
     color: var(--text-color);
 }
 
+.copy-section label {
+    display: block;
+    font-weight: 600;
+    margin: 15px 0 5px;
+    font-size: 16px;
+}
+
 .remove-icon {
     position: absolute;
     top: 10px;
@@ -132,6 +156,34 @@ h1 {
     align-items: center;
     z-index: 2;
     transition: background-color 0.3s ease;
+}
+
+.action-icons {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    gap: 5px;
+    z-index: 3;
+}
+
+.action-icons button {
+    background-color: rgba(255, 255, 255, 0.9);
+    border: none;
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s ease;
+}
+
+.action-icons button:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
 }
 
 .remove-icon:hover {
@@ -153,11 +205,20 @@ h1 {
 .remove-icon::after {
     transform: rotate(-45deg);
 }
+
+.safe-mask {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
 .dock {
     display: flex;
     justify-content: center;
-    position: absolute;
-    bottom: -50px;
+    position: fixed;
+    bottom: 20px;
     left: 50%;
     transform: translateX(-50%);
     background: rgba(0, 0, 0, 0.5);
@@ -165,6 +226,7 @@ h1 {
     padding: 10px 15px; /* Added a tiny bit of padding all around */
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     backdrop-filter: blur(10px);
+    z-index: 1000;
 }
 
 .export-btn {
@@ -185,4 +247,8 @@ h1 {
 
 .export-btn:hover {
     background: linear-gradient(135deg, rgba(255, 99, 71, 0.3) 0%, rgba(255, 99, 71, 0.3) 50%, rgba(255, 99, 71, 0.3) 100%); /* Burnt orange gradient effect on hover */
+}
+
+.toggle input {
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- limit uploads to 20 images
- crop images to 4×5 when creating moodboard PDFs
- show filenames under each cell and improve caption hierarchy
- document the upload limit and moodboard details in README
- generate moodboard and metadata PDFs in landscape orientation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c2d359ee083208c6c926a5f69d032